### PR TITLE
Optionally require a deposit to make a proposal

### DIFF
--- a/src/msg.rs
+++ b/src/msg.rs
@@ -17,6 +17,8 @@ pub struct InstantiateMsg {
     pub cw20_addr: String,
     pub threshold: Threshold,
     pub max_voting_period: Duration,
+    pub proposal_deposit_amount: Uint128,
+    pub proposal_deposit_token_address: String,
 }
 
 #[derive(Serialize, Deserialize, Clone, Copy, PartialEq, JsonSchema, Debug)]
@@ -142,6 +144,8 @@ pub enum ExecuteMsg {
     UpdateConfig {
         threshold: Threshold,
         max_voting_period: Duration,
+        proposal_deposit_amount: Uint128,
+        proposal_deposit_token_address: String,
     },
 }
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -2,7 +2,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
-use cosmwasm_std::{CosmosMsg, Decimal, Empty, Uint128};
+use cosmwasm_std::{Addr, CosmosMsg, Decimal, Empty, Uint128};
 use cw0::Expiration;
 
 use crate::msg::Vote;
@@ -91,6 +91,7 @@ where
     pub id: u64,
     pub title: String,
     pub description: String,
+    pub proposer: Addr,
     pub msgs: Vec<CosmosMsg<T>>,
     pub status: Status,
     pub expires: Expiration,
@@ -98,6 +99,8 @@ where
     /// as well as the total_weight of the voting group may have changed since this time. That means
     /// that the generic `Threshold{}` query does not provide valid information for existing proposals.
     pub threshold: ThresholdResponse,
+    pub deposit_amount: Uint128,
+    pub deposit_token_address: Addr,
 }
 
 #[derive(Serialize, Deserialize, Clone, Copy, PartialEq, JsonSchema, Debug)]

--- a/src/state.rs
+++ b/src/state.rs
@@ -20,12 +20,20 @@ pub struct Config {
     pub max_voting_period: Duration,
     // Total weight and voters are queried from this contract
     pub cw20_addr: Cw20Contract,
+    pub proposal_deposit: ProposalDeposit,
+}
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+pub struct ProposalDeposit {
+    pub amount: Uint128,
+    pub token_address: Cw20Contract,
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
 pub struct Proposal {
     pub title: String,
     pub description: String,
+    pub proposer: Addr,
     pub start_height: u64,
     pub expires: Expiration,
     pub msgs: Vec<CosmosMsg<Empty>>,
@@ -36,6 +44,7 @@ pub struct Proposal {
     pub total_weight: Uint128,
     // summary of existing votes
     pub votes: Votes,
+    pub deposit: ProposalDeposit,
 }
 
 // weight of votes for each option
@@ -231,6 +240,7 @@ mod test {
         let prop = Proposal {
             title: "Demo".to_string(),
             description: "Info".to_string(),
+            proposer: Addr::unchecked("test"),
             start_height: 100,
             expires,
             msgs: vec![],
@@ -238,6 +248,10 @@ mod test {
             threshold,
             total_weight,
             votes,
+            deposit: ProposalDeposit {
+                amount: Uint128::zero(),
+                token_address: Cw20Contract(Addr::unchecked("test")),
+            },
         };
         prop.is_passed(&block)
     }


### PR DESCRIPTION
This PR closes https://github.com/JakeHartnell/cw-dao/issues/1. 

The dao can now be configured to require a deposit to make a proposal. The deposit is returned if the proposal passes and becomes property of the dao if the proposal fails. 

This change will require future work to prevent the dao from accidentally spending proposal deposit funds. This will most likely be implemented by having a separate contract for managing the deposit funds to make the distinction more clear. 

This PR also persists the proposer's address to the proposal state object. This was necessary to return the proposal deposit and seems generally useful.