### PR TITLE
Use BalanceAtHeight

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,4 @@
+[alias]
+wasm = "build --release --target wasm32-unknown-unknown"
+wasm-debug = "build --target wasm32-unknown-unknown"
+unit-test = "test --lib"

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -28,14 +28,13 @@ jobs:
         env:
           RUST_BACKTRACE: 1
 
-      # TODO: Maybe get this working from root?
-      # - name: Compile WASM contract
-      #   uses: actions-rs/cargo@v1
-      #   with:
-      #     command: wasm
-      #     args: --locked
-      #   env:
-      #     RUSTFLAGS: "-C link-arg=-s"
+      - name: Compile WASM contract
+        uses: actions-rs/cargo@v1
+        with:
+          command: wasm
+          args: --locked
+        env:
+          RUSTFLAGS: "-C link-arg=-s"
 
   lints:
     name: Lints

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,6 +263,7 @@ dependencies = [
  "cw2",
  "cw20",
  "cw20-base",
+ "cw20-gov",
  "schemars",
  "serde",
  "thiserror",

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # cw20 DAO
 
+**NOT PRODUCTION READY**
+
 This builds on [cw3-flex-multisig](https://github.com/CosmWasm/cw-plus/tree/main/contracts/cw3-flex-multisig) and instead has the voting set maintained by cw20 tokens. This allows for the cw20s to serve as governance tokens in the DAO, similar to how governance tokens work using contracts like [Compound Governance](https://compound.finance/governance).
 
 ## Instantiation

--- a/contracts/cw-dao/Cargo.toml
+++ b/contracts/cw-dao/Cargo.toml
@@ -20,6 +20,7 @@ cw0 = {  version = "0.8.1" }
 cw2 = { version = "0.8.1" }
 cw20 ="0.8.1"
 cw20-base = {  version = "0.8.1", features = ["library"] }
+cw20-gov = { path = "../cw20-gov", version = "0.8.1" }
 cw-storage-plus = {  version = "0.8.1" }
 cosmwasm-std = { version = "0.16.0" }
 schemars = "0.8.1"

--- a/contracts/cw20-gov/examples/schema.rs
+++ b/contracts/cw20-gov/examples/schema.rs
@@ -20,6 +20,7 @@ fn main() {
     export_schema(&schema_for!(QueryMsg), &out_dir);
     export_schema(&schema_for!(AllowanceResponse), &out_dir);
     export_schema(&schema_for!(BalanceResponse), &out_dir);
+    export_schema(&schema_for!(BalanceAtHeightResponse), &out_dir);
     export_schema(&schema_for!(TokenInfoResponse), &out_dir);
     export_schema(&schema_for!(AllAllowancesResponse), &out_dir);
     export_schema(&schema_for!(AllAccountsResponse), &out_dir);

--- a/contracts/cw20-gov/schema/balance_at_height_response.json
+++ b/contracts/cw20-gov/schema/balance_at_height_response.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "BalanceAtHeightResponse",
+  "type": "object",
+  "required": [
+    "balance",
+    "height"
+  ],
+  "properties": {
+    "balance": {
+      "$ref": "#/definitions/Uint128"
+    },
+    "height": {
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0.0
+    }
+  },
+  "definitions": {
+    "Uint128": {
+      "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+      "type": "string"
+    }
+  }
+}


### PR DESCRIPTION
So this uses the new cw20-gov token and the new `BalanceAtHeight` query. Similary to compound, when someone votes it checks their balance at the start of the proposal.

Closes #17.

Also added some more CI stuff and updated the schema.