### PR TITLE
Delegate Votes

### DIFF
--- a/contracts/cw20-gov/schema/execute_msg.json
+++ b/contracts/cw20-gov/schema/execute_msg.json
@@ -1,9 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "Cw20ExecuteMsg",
+  "title": "ExecuteMsg",
   "anyOf": [
     {
-      "description": "Transfer is a base message to move tokens to another account without triggering actions",
       "type": "object",
       "required": [
         "transfer"
@@ -28,7 +27,6 @@
       "additionalProperties": false
     },
     {
-      "description": "Burn is a base message to destroy tokens forever",
       "type": "object",
       "required": [
         "burn"
@@ -49,7 +47,6 @@
       "additionalProperties": false
     },
     {
-      "description": "Send is a base message to transfer tokens to a contract and trigger an action on the receiving contract.",
       "type": "object",
       "required": [
         "send"
@@ -78,7 +75,6 @@
       "additionalProperties": false
     },
     {
-      "description": "Only with \"approval\" extension. Allows spender to access an additional amount tokens from the owner's (env.sender) account. If expires is Some(), overwrites current allowance expiration with this one.",
       "type": "object",
       "required": [
         "increase_allowance"
@@ -113,7 +109,6 @@
       "additionalProperties": false
     },
     {
-      "description": "Only with \"approval\" extension. Lowers the spender's access of tokens from the owner's (env.sender) account by amount. If expires is Some(), overwrites current allowance expiration with this one.",
       "type": "object",
       "required": [
         "decrease_allowance"
@@ -148,7 +143,6 @@
       "additionalProperties": false
     },
     {
-      "description": "Only with \"approval\" extension. Transfers amount tokens from owner -> recipient if `env.sender` has sufficient pre-approval.",
       "type": "object",
       "required": [
         "transfer_from"
@@ -177,7 +171,6 @@
       "additionalProperties": false
     },
     {
-      "description": "Only with \"approval\" extension. Sends amount tokens from owner -> contract if `env.sender` has sufficient pre-approval.",
       "type": "object",
       "required": [
         "send_from"
@@ -210,7 +203,6 @@
       "additionalProperties": false
     },
     {
-      "description": "Only with \"approval\" extension. Destroys tokens forever",
       "type": "object",
       "required": [
         "burn_from"
@@ -235,7 +227,6 @@
       "additionalProperties": false
     },
     {
-      "description": "Only with the \"mintable\" extension. If authorized, creates amount new tokens and adds to the recipient balance.",
       "type": "object",
       "required": [
         "mint"
@@ -260,7 +251,6 @@
       "additionalProperties": false
     },
     {
-      "description": "Only with the \"marketing\" extension. If authorized, updates marketing metadata. Setting None/null for any of these will leave it unchanged. Setting Some(\"\") will clear this field on the contract storage",
       "type": "object",
       "required": [
         "update_marketing"
@@ -270,21 +260,18 @@
           "type": "object",
           "properties": {
             "description": {
-              "description": "A longer description of the token and it's utility. Designed for tooltips or such",
               "type": [
                 "string",
                 "null"
               ]
             },
             "marketing": {
-              "description": "The address (if any) who can update this data structure",
               "type": [
                 "string",
                 "null"
               ]
             },
             "project": {
-              "description": "A URL pointing to the project behind this token.",
               "type": [
                 "string",
                 "null"
@@ -296,7 +283,6 @@
       "additionalProperties": false
     },
     {
-      "description": "If set as the \"marketing\" role on the contract, upload a new URL, SVG, or PNG for the token",
       "type": "object",
       "required": [
         "upload_logo"
@@ -304,6 +290,26 @@
       "properties": {
         "upload_logo": {
           "$ref": "#/definitions/Logo"
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "delegate_votes"
+      ],
+      "properties": {
+        "delegate_votes": {
+          "type": "object",
+          "required": [
+            "recipient"
+          ],
+          "properties": {
+            "recipient": {
+              "type": "string"
+            }
+          }
         }
       },
       "additionalProperties": false

--- a/contracts/cw20-gov/schema/query_msg.json
+++ b/contracts/cw20-gov/schema/query_msg.json
@@ -51,6 +51,27 @@
       "additionalProperties": false
     },
     {
+      "description": "Returns current delegation information Return type: DelegationResponse.",
+      "type": "object",
+      "required": [
+        "delegation"
+      ],
+      "properties": {
+        "delegation": {
+          "type": "object",
+          "required": [
+            "address"
+          ],
+          "properties": {
+            "address": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
       "description": "Returns metadata on the contract - name, decimals, supply, etc. Return type: TokenInfoResponse.",
       "type": "object",
       "required": [

--- a/contracts/cw20-gov/src/allowances.rs
+++ b/contracts/cw20-gov/src/allowances.rs
@@ -1,7 +1,7 @@
 use cosmwasm_std::{Binary, DepsMut, Env, MessageInfo, Response, StdResult, Uint128};
 use cw20_base::ContractError;
 
-use crate::state::VOTING_POWER;
+use crate::state::{VOTING_POWER, DELEGATIONS};
 
 pub fn execute_transfer_from(
     deps: DepsMut,
@@ -13,9 +13,11 @@ pub fn execute_transfer_from(
 ) -> Result<Response, ContractError> {
     let rcpt_addr = deps.api.addr_validate(&recipient)?;
     let owner_addr = deps.api.addr_validate(&owner)?;
+    let owner_delegation = DELEGATIONS.may_load(deps.storage, &owner_addr)?.unwrap_or(owner_addr.clone());
+    let recipient_delegation = DELEGATIONS.may_load(deps.storage, &rcpt_addr)?.unwrap_or(rcpt_addr.clone());
     VOTING_POWER.update(
         deps.storage,
-        &owner_addr,
+        &owner_delegation,
         env.block.height,
         |balance: Option<Uint128>| -> StdResult<_> {
             Ok(balance.unwrap_or_default().checked_sub(amount)?)
@@ -23,7 +25,7 @@ pub fn execute_transfer_from(
     )?;
     VOTING_POWER.update(
         deps.storage,
-        &rcpt_addr,
+        &recipient_delegation,
         env.block.height,
         |balance: Option<Uint128>| -> StdResult<_> { Ok(balance.unwrap_or_default() + amount) },
     )?;
@@ -39,10 +41,11 @@ pub fn execute_burn_from(
     amount: Uint128,
 ) -> Result<Response, ContractError> {
     let owner_addr = deps.api.addr_validate(&owner)?;
+    let owner_delegation = DELEGATIONS.may_load(deps.storage, &owner_addr)?.unwrap_or(owner_addr.clone());
     // lower balance
     VOTING_POWER.update(
         deps.storage,
-        &owner_addr,
+        &owner_delegation,
         env.block.height,
         |balance: Option<Uint128>| -> StdResult<_> {
             Ok(balance.unwrap_or_default().checked_sub(amount)?)
@@ -62,10 +65,12 @@ pub fn execute_send_from(
 ) -> Result<Response, ContractError> {
     let rcpt_addr = deps.api.addr_validate(&contract)?;
     let owner_addr = deps.api.addr_validate(&owner)?;
+    let owner_delegation = DELEGATIONS.may_load(deps.storage, &owner_addr)?.unwrap_or(owner_addr.clone());
+    let recipient_delegation = DELEGATIONS.may_load(deps.storage, &rcpt_addr)?.unwrap_or(rcpt_addr.clone());
     // move the tokens to the contract
     VOTING_POWER.update(
         deps.storage,
-        &owner_addr,
+        &owner_delegation,
         env.block.height,
         |balance: Option<Uint128>| -> StdResult<_> {
             Ok(balance.unwrap_or_default().checked_sub(amount)?)
@@ -73,7 +78,7 @@ pub fn execute_send_from(
     )?;
     VOTING_POWER.update(
         deps.storage,
-        &rcpt_addr,
+        &recipient_delegation,
         env.block.height,
         |balance: Option<Uint128>| -> StdResult<_> { Ok(balance.unwrap_or_default() + amount) },
     )?;
@@ -90,7 +95,7 @@ mod tests {
     use cw20_base::msg::InstantiateMsg;
     use cw20_base::ContractError;
 
-    use crate::contract::{execute, instantiate};
+    use crate::contract::{execute, instantiate, query_delegation, query_voting_power_at_height};
     use crate::msg::ExecuteMsg;
 
     use super::*;
@@ -380,5 +385,167 @@ mod tests {
         let env = mock_env();
         let err = execute(deps.as_mut(), env, info, msg).unwrap_err();
         assert_eq!(err, ContractError::Expired {});
+    }
+
+    #[test]
+    fn delegate_and_transfer_from() {
+        let mut deps = mock_dependencies(&[]);
+        let owner = String::from("addr0001");
+        let spender = String::from("addr0002");
+        let rcpt = String::from("addr0003");
+        let delegatee_1 = String::from("addr0004");
+        let delegatee_2 = String::from("addr0005");
+
+        let start = Uint128::new(999999);
+        do_instantiate(deps.as_mut(), &owner, start);
+
+        // delegate from owner to delegatee1
+        let info = mock_info(owner.as_ref(), &[]);
+        let env = mock_env();
+        let msg = ExecuteMsg::DelegateVotes {
+            recipient: delegatee_1.clone(),
+        };
+        let res = execute(deps.as_mut(), env.clone(), info, msg).unwrap();
+        assert_eq!(query_delegation(deps.as_ref(),owner.clone()).unwrap().delegation, delegatee_1);
+        assert_eq!(query_voting_power_at_height(deps.as_ref(),owner.clone(),env.block.height+1).unwrap().balance,Uint128::zero());
+        assert_eq!(query_voting_power_at_height(deps.as_ref(), delegatee_1.clone(), env.block.height+1).unwrap().balance, start);
+
+        // delegate from recpt to delegatee2
+        let info = mock_info(rcpt.as_ref(), &[]);
+        let env = mock_env();
+        let msg = ExecuteMsg::DelegateVotes {
+            recipient: delegatee_2.clone(),
+        };
+        let res = execute(deps.as_mut(), env.clone(), info, msg).unwrap();
+        assert_eq!(query_delegation(deps.as_ref(),owner.clone()).unwrap().delegation, delegatee_1);
+        assert_eq!(query_voting_power_at_height(deps.as_ref(),rcpt.clone(),env.block.height+1).unwrap().balance,Uint128::zero());
+        assert_eq!(query_voting_power_at_height(deps.as_ref(), rcpt.clone(), env.block.height+1).unwrap().balance, Uint128::zero());
+
+        // provide an allowance
+        let allow1 = Uint128::new(77777);
+        let msg = ExecuteMsg::IncreaseAllowance {
+            spender: spender.clone(),
+            amount: allow1,
+            expires: None,
+        };
+        let info = mock_info(owner.as_ref(), &[]);
+        execute(deps.as_mut(), env.clone(), info, msg).unwrap();
+
+        // valid transfer of part of the allowance
+        let transfer = Uint128::new(44444);
+        let msg = ExecuteMsg::TransferFrom {
+            owner: owner.clone(),
+            recipient: rcpt.clone(),
+            amount: transfer,
+        };
+        let info = mock_info(spender.as_ref(), &[]);
+        let res = execute(deps.as_mut(), env.clone(), info, msg).unwrap();
+        assert_eq!(query_voting_power_at_height(deps.as_ref(),owner.clone(),env.block.height+1).unwrap().balance,Uint128::zero());
+        assert_eq!(query_voting_power_at_height(deps.as_ref(), delegatee_1.clone(), env.block.height+1).unwrap().balance, start.checked_sub(transfer).unwrap());
+        assert_eq!(query_voting_power_at_height(deps.as_ref(),delegatee_2.clone(),env.block.height+1).unwrap().balance,transfer);
+    }
+
+    #[test]
+    fn delegate_and_burn_from() {
+        let mut deps = mock_dependencies(&[]);
+        let owner = String::from("addr0001");
+        let spender = String::from("addr0002");
+        let delegatee = String::from("addr0003");
+
+        let start = Uint128::new(999999);
+        do_instantiate(deps.as_mut(), &owner, start);
+
+        // delegate from owner to delegatee1
+        let info = mock_info(owner.as_ref(), &[]);
+        let env = mock_env();
+        let msg = ExecuteMsg::DelegateVotes {
+            recipient: delegatee.clone(),
+        };
+        let res = execute(deps.as_mut(), env.clone(), info, msg).unwrap();
+        assert_eq!(query_delegation(deps.as_ref(), owner.clone()).unwrap().delegation, delegatee);
+        assert_eq!(query_voting_power_at_height(deps.as_ref(), owner.clone(), env.block.height + 1).unwrap().balance, Uint128::zero());
+        assert_eq!(query_voting_power_at_height(deps.as_ref(), delegatee.clone(), env.block.height + 1).unwrap().balance, start);
+
+        // provide an allowance
+        let allow1 = Uint128::new(77777);
+        let msg = ExecuteMsg::IncreaseAllowance {
+            spender: spender.clone(),
+            amount: allow1,
+            expires: None,
+        };
+        let info = mock_info(owner.as_ref(), &[]);
+        execute(deps.as_mut(), env.clone(), info, msg).unwrap();
+
+        // valid burn of part of the allowance
+        let burn = Uint128::new(44444);
+        let msg = ExecuteMsg::BurnFrom {
+            owner: owner.clone(),
+            amount: burn,
+        };
+        let info = mock_info(spender.as_ref(), &[]);
+        let res = execute(deps.as_mut(), env.clone(), info, msg).unwrap();
+        assert_eq!(res.attributes[0], attr("action", "burn_from"));
+        assert_eq!(query_voting_power_at_height(deps.as_ref(), owner.clone(), env.block.height + 1).unwrap().balance, Uint128::zero());
+        assert_eq!(query_voting_power_at_height(deps.as_ref(), delegatee.clone(), env.block.height + 1).unwrap().balance, start-burn);
+    }
+
+    #[test]
+    fn delegate_and_send_from() {
+        let mut deps = mock_dependencies(&[]);
+        let owner = String::from("addr0001");
+        let spender = String::from("addr0002");
+        let rcpt = String::from("addr0003");
+        let delegatee_1 = String::from("addr0004");
+        let delegatee_2 = String::from("addr0005");
+
+        let start = Uint128::new(999999);
+        do_instantiate(deps.as_mut(), &owner, start);
+
+        // delegate from owner to delegatee1
+        let info = mock_info(owner.as_ref(), &[]);
+        let env = mock_env();
+        let msg = ExecuteMsg::DelegateVotes {
+            recipient: delegatee_1.clone(),
+        };
+        let res = execute(deps.as_mut(), env.clone(), info, msg).unwrap();
+        assert_eq!(query_delegation(deps.as_ref(),owner.clone()).unwrap().delegation, delegatee_1);
+        assert_eq!(query_voting_power_at_height(deps.as_ref(),owner.clone(),env.block.height+1).unwrap().balance,Uint128::zero());
+        assert_eq!(query_voting_power_at_height(deps.as_ref(), delegatee_1.clone(), env.block.height+1).unwrap().balance, start);
+
+        // delegate from recpt to delegatee2
+        let info = mock_info(rcpt.as_ref(), &[]);
+        let env = mock_env();
+        let msg = ExecuteMsg::DelegateVotes {
+            recipient: delegatee_2.clone(),
+        };
+        let res = execute(deps.as_mut(), env.clone(), info, msg).unwrap();
+        assert_eq!(query_delegation(deps.as_ref(),owner.clone()).unwrap().delegation, delegatee_1);
+        assert_eq!(query_voting_power_at_height(deps.as_ref(),rcpt.clone(),env.block.height+1).unwrap().balance,Uint128::zero());
+        assert_eq!(query_voting_power_at_height(deps.as_ref(), rcpt.clone(), env.block.height+1).unwrap().balance, Uint128::zero());
+
+        // provide an allowance
+        let allow1 = Uint128::new(77777);
+        let msg = ExecuteMsg::IncreaseAllowance {
+            spender: spender.clone(),
+            amount: allow1,
+            expires: None,
+        };
+        let info = mock_info(owner.as_ref(), &[]);
+        execute(deps.as_mut(), env.clone(), info, msg).unwrap();
+
+        // valid transfer of part of the allowance
+        let transfer = Uint128::new(44444);
+        let send_msg = Binary::from(r#"{"some":123}"#.as_bytes());
+        let msg = ExecuteMsg::SendFrom {
+            owner: owner.clone(),
+            contract: rcpt.clone(),
+            amount: transfer,
+            msg: send_msg,
+        };
+        let info = mock_info(spender.as_ref(), &[]);
+        let res = execute(deps.as_mut(), env.clone(), info, msg).unwrap();
+        assert_eq!(query_voting_power_at_height(deps.as_ref(),owner.clone(),env.block.height+1).unwrap().balance,Uint128::zero());
+        assert_eq!(query_voting_power_at_height(deps.as_ref(), delegatee_1.clone(), env.block.height+1).unwrap().balance, start.checked_sub(transfer).unwrap());
+        assert_eq!(query_voting_power_at_height(deps.as_ref(),delegatee_2.clone(),env.block.height+1).unwrap().balance,transfer);
     }
 }

--- a/contracts/cw20-gov/src/allowances.rs
+++ b/contracts/cw20-gov/src/allowances.rs
@@ -401,25 +401,26 @@ mod tests {
 
         // delegate from owner to delegatee1
         let info = mock_info(owner.as_ref(), &[]);
-        let env = mock_env();
+        let mut env = mock_env();
         let msg = ExecuteMsg::DelegateVotes {
             recipient: delegatee_1.clone(),
         };
         let res = execute(deps.as_mut(), env.clone(), info, msg).unwrap();
+        env.block.height += 1;
         assert_eq!(query_delegation(deps.as_ref(),owner.clone()).unwrap().delegation, delegatee_1);
-        assert_eq!(query_voting_power_at_height(deps.as_ref(),owner.clone(),env.block.height+1).unwrap().balance,Uint128::zero());
-        assert_eq!(query_voting_power_at_height(deps.as_ref(), delegatee_1.clone(), env.block.height+1).unwrap().balance, start);
+        assert_eq!(query_voting_power_at_height(deps.as_ref(),owner.clone(),env.block.height).unwrap().balance,Uint128::zero());
+        assert_eq!(query_voting_power_at_height(deps.as_ref(), delegatee_1.clone(), env.block.height).unwrap().balance, start);
 
         // delegate from recpt to delegatee2
         let info = mock_info(rcpt.as_ref(), &[]);
-        let env = mock_env();
         let msg = ExecuteMsg::DelegateVotes {
             recipient: delegatee_2.clone(),
         };
         let res = execute(deps.as_mut(), env.clone(), info, msg).unwrap();
+        env.block.height += 1;
         assert_eq!(query_delegation(deps.as_ref(),owner.clone()).unwrap().delegation, delegatee_1);
-        assert_eq!(query_voting_power_at_height(deps.as_ref(),rcpt.clone(),env.block.height+1).unwrap().balance,Uint128::zero());
-        assert_eq!(query_voting_power_at_height(deps.as_ref(), rcpt.clone(), env.block.height+1).unwrap().balance, Uint128::zero());
+        assert_eq!(query_voting_power_at_height(deps.as_ref(),rcpt.clone(),env.block.height).unwrap().balance,Uint128::zero());
+        assert_eq!(query_voting_power_at_height(deps.as_ref(), rcpt.clone(), env.block.height).unwrap().balance, Uint128::zero());
 
         // provide an allowance
         let allow1 = Uint128::new(77777);
@@ -440,9 +441,10 @@ mod tests {
         };
         let info = mock_info(spender.as_ref(), &[]);
         let res = execute(deps.as_mut(), env.clone(), info, msg).unwrap();
-        assert_eq!(query_voting_power_at_height(deps.as_ref(),owner.clone(),env.block.height+1).unwrap().balance,Uint128::zero());
-        assert_eq!(query_voting_power_at_height(deps.as_ref(), delegatee_1.clone(), env.block.height+1).unwrap().balance, start.checked_sub(transfer).unwrap());
-        assert_eq!(query_voting_power_at_height(deps.as_ref(),delegatee_2.clone(),env.block.height+1).unwrap().balance,transfer);
+        env.block.height += 1;
+        assert_eq!(query_voting_power_at_height(deps.as_ref(),owner.clone(),env.block.height).unwrap().balance,Uint128::zero());
+        assert_eq!(query_voting_power_at_height(deps.as_ref(), delegatee_1.clone(), env.block.height).unwrap().balance, start.checked_sub(transfer).unwrap());
+        assert_eq!(query_voting_power_at_height(deps.as_ref(),delegatee_2.clone(),env.block.height).unwrap().balance,transfer);
     }
 
     #[test]
@@ -457,14 +459,15 @@ mod tests {
 
         // delegate from owner to delegatee1
         let info = mock_info(owner.as_ref(), &[]);
-        let env = mock_env();
+        let mut env = mock_env();
         let msg = ExecuteMsg::DelegateVotes {
             recipient: delegatee.clone(),
         };
         let res = execute(deps.as_mut(), env.clone(), info, msg).unwrap();
+        env.block.height += 1;
         assert_eq!(query_delegation(deps.as_ref(), owner.clone()).unwrap().delegation, delegatee);
-        assert_eq!(query_voting_power_at_height(deps.as_ref(), owner.clone(), env.block.height + 1).unwrap().balance, Uint128::zero());
-        assert_eq!(query_voting_power_at_height(deps.as_ref(), delegatee.clone(), env.block.height + 1).unwrap().balance, start);
+        assert_eq!(query_voting_power_at_height(deps.as_ref(), owner.clone(), env.block.height).unwrap().balance, Uint128::zero());
+        assert_eq!(query_voting_power_at_height(deps.as_ref(), delegatee.clone(), env.block.height).unwrap().balance, start);
 
         // provide an allowance
         let allow1 = Uint128::new(77777);
@@ -484,9 +487,10 @@ mod tests {
         };
         let info = mock_info(spender.as_ref(), &[]);
         let res = execute(deps.as_mut(), env.clone(), info, msg).unwrap();
+        env.block.height += 1;
         assert_eq!(res.attributes[0], attr("action", "burn_from"));
-        assert_eq!(query_voting_power_at_height(deps.as_ref(), owner.clone(), env.block.height + 1).unwrap().balance, Uint128::zero());
-        assert_eq!(query_voting_power_at_height(deps.as_ref(), delegatee.clone(), env.block.height + 1).unwrap().balance, start-burn);
+        assert_eq!(query_voting_power_at_height(deps.as_ref(), owner.clone(), env.block.height).unwrap().balance, Uint128::zero());
+        assert_eq!(query_voting_power_at_height(deps.as_ref(), delegatee.clone(), env.block.height).unwrap().balance, start-burn);
     }
 
     #[test]
@@ -503,25 +507,26 @@ mod tests {
 
         // delegate from owner to delegatee1
         let info = mock_info(owner.as_ref(), &[]);
-        let env = mock_env();
+        let mut env = mock_env();
         let msg = ExecuteMsg::DelegateVotes {
             recipient: delegatee_1.clone(),
         };
         let res = execute(deps.as_mut(), env.clone(), info, msg).unwrap();
+        env.block.height += 1;
         assert_eq!(query_delegation(deps.as_ref(),owner.clone()).unwrap().delegation, delegatee_1);
-        assert_eq!(query_voting_power_at_height(deps.as_ref(),owner.clone(),env.block.height+1).unwrap().balance,Uint128::zero());
-        assert_eq!(query_voting_power_at_height(deps.as_ref(), delegatee_1.clone(), env.block.height+1).unwrap().balance, start);
+        assert_eq!(query_voting_power_at_height(deps.as_ref(),owner.clone(),env.block.height).unwrap().balance,Uint128::zero());
+        assert_eq!(query_voting_power_at_height(deps.as_ref(), delegatee_1.clone(), env.block.height).unwrap().balance, start);
 
         // delegate from recpt to delegatee2
         let info = mock_info(rcpt.as_ref(), &[]);
-        let env = mock_env();
         let msg = ExecuteMsg::DelegateVotes {
             recipient: delegatee_2.clone(),
         };
         let res = execute(deps.as_mut(), env.clone(), info, msg).unwrap();
+        env.block.height += 1;
         assert_eq!(query_delegation(deps.as_ref(),owner.clone()).unwrap().delegation, delegatee_1);
-        assert_eq!(query_voting_power_at_height(deps.as_ref(),rcpt.clone(),env.block.height+1).unwrap().balance,Uint128::zero());
-        assert_eq!(query_voting_power_at_height(deps.as_ref(), rcpt.clone(), env.block.height+1).unwrap().balance, Uint128::zero());
+        assert_eq!(query_voting_power_at_height(deps.as_ref(),rcpt.clone(),env.block.height).unwrap().balance,Uint128::zero());
+        assert_eq!(query_voting_power_at_height(deps.as_ref(), rcpt.clone(), env.block.height).unwrap().balance, Uint128::zero());
 
         // provide an allowance
         let allow1 = Uint128::new(77777);
@@ -544,8 +549,9 @@ mod tests {
         };
         let info = mock_info(spender.as_ref(), &[]);
         let res = execute(deps.as_mut(), env.clone(), info, msg).unwrap();
-        assert_eq!(query_voting_power_at_height(deps.as_ref(),owner.clone(),env.block.height+1).unwrap().balance,Uint128::zero());
-        assert_eq!(query_voting_power_at_height(deps.as_ref(), delegatee_1.clone(), env.block.height+1).unwrap().balance, start.checked_sub(transfer).unwrap());
-        assert_eq!(query_voting_power_at_height(deps.as_ref(),delegatee_2.clone(),env.block.height+1).unwrap().balance,transfer);
+        env.block.height += 1;
+        assert_eq!(query_voting_power_at_height(deps.as_ref(),owner.clone(),env.block.height).unwrap().balance,Uint128::zero());
+        assert_eq!(query_voting_power_at_height(deps.as_ref(), delegatee_1.clone(), env.block.height).unwrap().balance, start.checked_sub(transfer).unwrap());
+        assert_eq!(query_voting_power_at_height(deps.as_ref(),delegatee_2.clone(),env.block.height).unwrap().balance,transfer);
     }
 }

--- a/contracts/cw20-gov/src/contract.rs
+++ b/contracts/cw20-gov/src/contract.rs
@@ -857,14 +857,15 @@ mod tests {
 
         // delegate from addr1 to addr2
         let info = mock_info(addr1.as_ref(), &[]);
-        let env = mock_env();
+        let mut env = mock_env();
         let msg = ExecuteMsg::DelegateVotes {
             recipient: addr2.clone(),
         };
         let res = execute(deps.as_mut(), env.clone(), info, msg).unwrap();
+        env.block.height += 1;
         assert_eq!(query_delegation(deps.as_ref(),addr1.clone()).unwrap().delegation, addr2);
-        assert_eq!(query_voting_power_at_height(deps.as_ref(),addr1.clone(),env.block.height+1).unwrap().balance,Uint128::zero());
-        assert_eq!(query_voting_power_at_height(deps.as_ref(),addr2.clone(),env.block.height+1).unwrap().balance,amount1);
+        assert_eq!(query_voting_power_at_height(deps.as_ref(),addr1.clone(),env.block.height).unwrap().balance,Uint128::zero());
+        assert_eq!(query_voting_power_at_height(deps.as_ref(),addr2.clone(),env.block.height).unwrap().balance,amount1);
 
         // send tokens and assert delegation changes
         let info = mock_info(addr1.as_ref(), &[]);
@@ -873,9 +874,10 @@ mod tests {
             amount: transfer,
         };
         let res = execute(deps.as_mut(), env.clone(), info, msg).unwrap();
-        assert_eq!(query_voting_power_at_height(deps.as_ref(),addr1.clone(),env.block.height+1).unwrap().balance,Uint128::zero());
-        assert_eq!(query_voting_power_at_height(deps.as_ref(),addr2.clone(),env.block.height+1).unwrap().balance,amount1.checked_sub(transfer).unwrap());
-        assert_eq!(query_voting_power_at_height(deps.as_ref(),addr3.clone(),env.block.height+1).unwrap().balance,transfer);
+        env.block.height += 1;
+        assert_eq!(query_voting_power_at_height(deps.as_ref(),addr1.clone(),env.block.height).unwrap().balance,Uint128::zero());
+        assert_eq!(query_voting_power_at_height(deps.as_ref(),addr2.clone(),env.block.height).unwrap().balance,amount1.checked_sub(transfer).unwrap());
+        assert_eq!(query_voting_power_at_height(deps.as_ref(),addr3.clone(),env.block.height).unwrap().balance,transfer);
     }
 
     #[test]
@@ -893,14 +895,15 @@ mod tests {
 
         // delegate from addr1 to addr2
         let info = mock_info(addr1.as_ref(), &[]);
-        let env = mock_env();
+        let mut env = mock_env();
         let msg = ExecuteMsg::DelegateVotes {
             recipient: addr2.clone(),
         };
         let res = execute(deps.as_mut(), env.clone(), info, msg).unwrap();
+        env.block.height += 1;
         assert_eq!(query_delegation(deps.as_ref(),addr1.clone()).unwrap().delegation, addr2);
-        assert_eq!(query_voting_power_at_height(deps.as_ref(),addr1.clone(),env.block.height+1).unwrap().balance,Uint128::zero());
-        assert_eq!(query_voting_power_at_height(deps.as_ref(),addr2.clone(),env.block.height+1).unwrap().balance,amount1);
+        assert_eq!(query_voting_power_at_height(deps.as_ref(),addr1.clone(),env.block.height).unwrap().balance,Uint128::zero());
+        assert_eq!(query_voting_power_at_height(deps.as_ref(),addr2.clone(),env.block.height).unwrap().balance,amount1);
 
         let info = mock_info(addr1.as_ref(), &[]);
         let msg = ExecuteMsg::Send {
@@ -909,9 +912,10 @@ mod tests {
             msg: send_msg.clone(),
         };
         let res = execute(deps.as_mut(), env.clone(), info, msg).unwrap();
-        assert_eq!(query_voting_power_at_height(deps.as_ref(),addr1.clone(),env.block.height+1).unwrap().balance,Uint128::zero());
-        assert_eq!(query_voting_power_at_height(deps.as_ref(),addr2.clone(),env.block.height+1).unwrap().balance,amount1.checked_sub(transfer).unwrap());
-        assert_eq!(query_voting_power_at_height(deps.as_ref(),contract.clone(),env.block.height+1).unwrap().balance,transfer);
+        env.block.height += 1;
+        assert_eq!(query_voting_power_at_height(deps.as_ref(),addr1.clone(),env.block.height).unwrap().balance,Uint128::zero());
+        assert_eq!(query_voting_power_at_height(deps.as_ref(),addr2.clone(),env.block.height).unwrap().balance,amount1.checked_sub(transfer).unwrap());
+        assert_eq!(query_voting_power_at_height(deps.as_ref(),contract.clone(),env.block.height).unwrap().balance,transfer);
     }
 
     #[test]
@@ -929,14 +933,15 @@ mod tests {
 
         // delegate from addr1 to addr2
         let info = mock_info(addr1.as_ref(), &[]);
-        let env = mock_env();
+        let mut env = mock_env();
         let msg = ExecuteMsg::DelegateVotes {
             recipient: addr2.clone(),
         };
         let res = execute(deps.as_mut(), env.clone(), info, msg).unwrap();
+        env.block.height += 1;
         assert_eq!(query_delegation(deps.as_ref(),addr1.clone()).unwrap().delegation, addr2);
-        assert_eq!(query_voting_power_at_height(deps.as_ref(),addr1.clone(),env.block.height+1).unwrap().balance,Uint128::zero());
-        assert_eq!(query_voting_power_at_height(deps.as_ref(),addr2.clone(),env.block.height+1).unwrap().balance, genesis_amount);
+        assert_eq!(query_voting_power_at_height(deps.as_ref(),addr1.clone(),env.block.height).unwrap().balance,Uint128::zero());
+        assert_eq!(query_voting_power_at_height(deps.as_ref(),addr2.clone(),env.block.height).unwrap().balance, genesis_amount);
 
         // minted coins increase delegation
         let msg = ExecuteMsg::Mint {
@@ -946,9 +951,10 @@ mod tests {
 
         let info = mock_info(minter.as_ref(), &[]);
         let res = execute(deps.as_mut(), env.clone(), info, msg).unwrap();
+        env.block.height += 1;
         assert_eq!(0, res.messages.len());
-        assert_eq!(query_voting_power_at_height(deps.as_ref(),addr1.clone(),env.block.height+1).unwrap().balance,Uint128::zero());
-        assert_eq!(query_voting_power_at_height(deps.as_ref(),addr2.clone(),env.block.height+1).unwrap().balance, genesis_amount+mint_amount);
+        assert_eq!(query_voting_power_at_height(deps.as_ref(),addr1.clone(),env.block.height).unwrap().balance,Uint128::zero());
+        assert_eq!(query_voting_power_at_height(deps.as_ref(),addr2.clone(),env.block.height).unwrap().balance, genesis_amount+mint_amount);
     }
 
     #[test]
@@ -963,22 +969,24 @@ mod tests {
 
         // delegate from addr1 to addr2
         let info = mock_info(addr1.as_ref(), &[]);
-        let env = mock_env();
+        let mut env = mock_env();
         let msg = ExecuteMsg::DelegateVotes {
             recipient: addr2.clone(),
         };
         let res = execute(deps.as_mut(), env.clone(), info, msg).unwrap();
+        env.block.height += 1;
         assert_eq!(query_delegation(deps.as_ref(),addr1.clone()).unwrap().delegation, addr2);
-        assert_eq!(query_voting_power_at_height(deps.as_ref(),addr1.clone(),env.block.height+1).unwrap().balance,Uint128::zero());
-        assert_eq!(query_voting_power_at_height(deps.as_ref(),addr2.clone(),env.block.height+1).unwrap().balance, genesis_amount);
+        assert_eq!(query_voting_power_at_height(deps.as_ref(),addr1.clone(),env.block.height).unwrap().balance,Uint128::zero());
+        assert_eq!(query_voting_power_at_height(deps.as_ref(),addr2.clone(),env.block.height).unwrap().balance, genesis_amount);
 
 
         // valid burn reduces total supply
         let info = mock_info(addr1.as_ref(), &[]);
         let msg = ExecuteMsg::Burn { amount: burn_amount };
         let res = execute(deps.as_mut(), env.clone(), info, msg).unwrap();
+        env.block.height += 1;
         assert_eq!(res.messages.len(), 0);
-        assert_eq!(query_voting_power_at_height(deps.as_ref(),addr1.clone(),env.block.height+1).unwrap().balance,Uint128::zero());
-        assert_eq!(query_voting_power_at_height(deps.as_ref(),addr2.clone(),env.block.height+1).unwrap().balance, genesis_amount-burn_amount);
+        assert_eq!(query_voting_power_at_height(deps.as_ref(),addr1.clone(),env.block.height).unwrap().balance,Uint128::zero());
+        assert_eq!(query_voting_power_at_height(deps.as_ref(),addr2.clone(),env.block.height).unwrap().balance, genesis_amount-burn_amount);
     }
 }

--- a/contracts/cw20-gov/src/msg.rs
+++ b/contracts/cw20-gov/src/msg.rs
@@ -1,7 +1,60 @@
-use cosmwasm_std::Uint128;
-pub use cw20::Cw20ExecuteMsg as ExecuteMsg;
+use cosmwasm_std::{Uint128, Binary, Addr};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use cw20::{Expiration, Logo};
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecuteMsg {
+    Transfer {
+        recipient: String,
+        amount: Uint128,
+    },
+    Burn {
+        amount: Uint128,
+    },
+    Send {
+        contract: String,
+        amount: Uint128,
+        msg: Binary,
+    },
+    IncreaseAllowance {
+        spender: String,
+        amount: Uint128,
+        expires: Option<Expiration>,
+    },
+    DecreaseAllowance {
+        spender: String,
+        amount: Uint128,
+        expires: Option<Expiration>,
+    },
+    TransferFrom {
+        owner: String,
+        recipient: String,
+        amount: Uint128,
+    },
+    SendFrom {
+        owner: String,
+        contract: String,
+        amount: Uint128,
+        msg: Binary,
+    },
+    BurnFrom {
+        owner: String,
+        amount: Uint128,
+    },
+    Mint {
+        recipient: String,
+        amount: Uint128,
+    },
+    UpdateMarketing {
+        project: Option<String>,
+        description: Option<String>,
+        marketing: Option<String>,
+    },
+    UploadLogo(Logo),
+    DelegateVotes{recipient: String},
+}
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
@@ -12,6 +65,9 @@ pub enum QueryMsg {
     /// Returns the balance of the given address at given height, 0 if unset.
     /// Return type: BalanceAtHeightResponse.
     VotingPowerAtHeight { address: String, height: u64 },
+    /// Returns current delegation information
+    /// Return type: DelegationResponse.
+    Delegation { address: String},
     /// Returns metadata on the contract - name, decimals, supply, etc.
     /// Return type: TokenInfoResponse.
     TokenInfo {},
@@ -54,4 +110,9 @@ pub enum QueryMsg {
 pub struct VotingPowerAtHeightResponse {
     pub balance: Uint128,
     pub height: u64,
+}
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+pub struct DelegationResponse {
+    pub delegation: String,
 }

--- a/contracts/cw20-gov/src/msg.rs
+++ b/contracts/cw20-gov/src/msg.rs
@@ -1,7 +1,7 @@
-use cosmwasm_std::{Uint128, Binary, Addr};
+use cosmwasm_std::{Binary, Uint128};
+use cw20::{Expiration, Logo};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use cw20::{Expiration, Logo};
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
@@ -53,7 +53,9 @@ pub enum ExecuteMsg {
         marketing: Option<String>,
     },
     UploadLogo(Logo),
-    DelegateVotes{recipient: String},
+    DelegateVotes {
+        recipient: String,
+    },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -67,7 +69,7 @@ pub enum QueryMsg {
     VotingPowerAtHeight { address: String, height: u64 },
     /// Returns current delegation information
     /// Return type: DelegationResponse.
-    Delegation { address: String},
+    Delegation { address: String },
     /// Returns metadata on the contract - name, decimals, supply, etc.
     /// Return type: TokenInfoResponse.
     TokenInfo {},

--- a/contracts/cw20-gov/src/state.rs
+++ b/contracts/cw20-gov/src/state.rs
@@ -9,4 +9,4 @@ pub const VOTING_POWER: SnapshotMap<&Addr, Uint128> = SnapshotMap::new(
 );
 
 // TODO: implement this feature
-pub const DELEGATIONS: Map<&Addr, &Addr> = Map::new("delegations");
+pub const DELEGATIONS: Map<&Addr, Addr> = Map::new("delegations");


### PR DESCRIPTION
This PR closes #18. It implements delegation of votes to other addresses. 

This was implemented by converting the balance snapshot map to voting power and reusing the base cw20 balance map as the store for the actual balances. As a bonus, this allows us to reuse the cw20-base instantiate method.

This implementation allows each address to delegate all votes to one other address. Partial delegations added too much complexity and state for the initial implementation IMO. The user can still make partial delegation by splitting their tokens into multiple accounts if they have a strong reason to do so. 

When token balance is mutated through transfers, burns, or mints, delegations are automatically updated. On transfers the voting power of delagatees of both the sender and receiver will be updated. 

Another caveat is the delegation graph is limited to one level. IE if Address A delegates to Address B and Address B delegates to Address C, Address A's delegation does not flow through to Address C and Address B can still vote with Address A's delegation even though their own balance is delegated to Address C. This choice makes implementation much easier as we do not need to traverse an arbitrarily long graph when the tokens transfer and we do not need to worry about circular paths. I think the subset of users who will both be delegated to and delegate will be small and we most likely do not need to worry about this use case. 

The current method to undelegate is just to delegate to yourself. This is probable fine but might be better UX to have a undelegate method.